### PR TITLE
Refactor parameter schema defaults

### DIFF
--- a/interface/parameter_schema.py
+++ b/interface/parameter_schema.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Type
+import copy
 
 
 @dataclass
@@ -214,11 +215,15 @@ class SamplingControlParameters:
 class RDEEParameterSchema:
     """Root schema containing all parameter groups for RDEE."""
 
-    cosmological: CosmologicalParameters = CosmologicalParameters()
-    stellar: StellarParameters = StellarParameters()
-    planetary: PlanetaryParameters = PlanetaryParameters()
-    habitability: HabitabilityParameters = HabitabilityParameters()
-    prebiotic: PrebioticChemistryParameters = PrebioticChemistryParameters()
-    evolutionary: EvolutionaryParameters = EvolutionaryParameters()
-    sampling: SamplingControlParameters = SamplingControlParameters()
+    cosmological: CosmologicalParameters = field(default_factory=CosmologicalParameters)
+    stellar: StellarParameters = field(default_factory=StellarParameters)
+    planetary: PlanetaryParameters = field(default_factory=PlanetaryParameters)
+    habitability: HabitabilityParameters = field(default_factory=HabitabilityParameters)
+    prebiotic: PrebioticChemistryParameters = field(default_factory=PrebioticChemistryParameters)
+    evolutionary: EvolutionaryParameters = field(default_factory=EvolutionaryParameters)
+    sampling: SamplingControlParameters = field(default_factory=SamplingControlParameters)
+
+    def clone(self) -> "RDEEParameterSchema":
+        """Return a deep-copy clone of the current parameter schema, safe for independent simulation mutation."""
+        return copy.deepcopy(self)
 


### PR DESCRIPTION
## Summary
- use `field(default_factory=...)` for nested parameter groups
- add a `clone` helper for deep-copying parameter schemas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7418a1988322a8440c91ab577523