### PR TITLE
Add ExecutionMonitor

### DIFF
--- a/orchestration/execution_monitor.py
+++ b/orchestration/execution_monitor.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Execution monitoring utilities for orchestration layer."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class ExecutionMonitor:
+    """Track high-level execution statistics across simulation batches."""
+
+    total_runs: int = field(init=False, default=0)
+    valid_runs: int = field(init=False, default=0)
+    failed_validations: int = field(init=False, default=0)
+    successful_storage: int = field(init=False, default=0)
+    storage_failures: int = field(init=False, default=0)
+    recursion_depths: List[int] = field(init=False, default_factory=list)
+
+    def __init__(self) -> None:
+        """Initialize all counters and storage containers."""
+        self.total_runs = 0
+        self.valid_runs = 0
+        self.failed_validations = 0
+        self.successful_storage = 0
+        self.storage_failures = 0
+        self.recursion_depths = []
+
+    def register_validation(self, success: bool) -> None:
+        """Record the result of a validation step.
+
+        Parameters
+        ----------
+        success:
+            ``True`` if validation succeeded, ``False`` otherwise.
+        """
+        if not isinstance(success, bool):
+            raise TypeError("success must be a bool")
+        self.total_runs += 1
+        if success:
+            self.valid_runs += 1
+        else:
+            self.failed_validations += 1
+
+    def register_storage(self, success: bool) -> None:
+        """Record the outcome of a storage operation.
+
+        Parameters
+        ----------
+        success:
+            ``True`` if the operation succeeded, ``False`` otherwise.
+        """
+        if not isinstance(success, bool):
+            raise TypeError("success must be a bool")
+        if success:
+            self.successful_storage += 1
+        else:
+            self.storage_failures += 1
+
+    def register_depth(self, depth: int) -> None:
+        """Store the recursion depth for a completed run.
+
+        Parameters
+        ----------
+        depth:
+            The recursion depth reached during execution.
+
+        Raises
+        ------
+        ValueError
+            If ``depth`` is negative.
+        """
+        if depth < 0:
+            raise ValueError("depth must be non-negative")
+        self.recursion_depths.append(depth)
+
+    def report(self) -> Dict[str, float | int]:
+        """Return a summary of the current monitoring statistics."""
+        if self.recursion_depths:
+            average_depth = sum(self.recursion_depths) / len(self.recursion_depths)
+        else:
+            average_depth = 0.0
+        return {
+            "total_runs": self.total_runs,
+            "valid_runs": self.valid_runs,
+            "failed_validations": self.failed_validations,
+            "successful_storage": self.successful_storage,
+            "storage_failures": self.storage_failures,
+            "average_recursion_depth": float(average_depth),
+        }

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from orchestration.execution_monitor import ExecutionMonitor
+
+
+def test_initialization() -> None:
+    monitor = ExecutionMonitor()
+    assert monitor.total_runs == 0
+    assert monitor.valid_runs == 0
+    assert monitor.failed_validations == 0
+    assert monitor.successful_storage == 0
+    assert monitor.storage_failures == 0
+    assert monitor.recursion_depths == []
+    report = monitor.report()
+    assert report["total_runs"] == 0
+    assert report["average_recursion_depth"] == 0.0
+
+
+def test_register_validation() -> None:
+    monitor = ExecutionMonitor()
+    monitor.register_validation(True)
+    monitor.register_validation(False)
+    assert monitor.total_runs == 2
+    assert monitor.valid_runs == 1
+    assert monitor.failed_validations == 1
+
+
+def test_register_storage() -> None:
+    monitor = ExecutionMonitor()
+    monitor.register_storage(True)
+    monitor.register_storage(False)
+    assert monitor.successful_storage == 1
+    assert monitor.storage_failures == 1
+
+
+def test_register_depth_and_report() -> None:
+    monitor = ExecutionMonitor()
+    monitor.register_depth(2)
+    monitor.register_depth(4)
+    assert monitor.recursion_depths == [2, 4]
+    report = monitor.report()
+    assert report["average_recursion_depth"] == pytest.approx(3.0)
+
+
+def test_invalid_inputs() -> None:
+    monitor = ExecutionMonitor()
+    with pytest.raises(TypeError):
+        monitor.register_validation(1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        monitor.register_storage(0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        monitor.register_depth(-1)


### PR DESCRIPTION
## Summary
- implement `ExecutionMonitor` in `orchestration/execution_monitor.py`
- add unit tests for the monitor in `tests/test_orchestration.py`

## Testing
- `PYTHONPATH=. pytest tests/test_orchestration.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'interface')*

------
https://chatgpt.com/codex/tasks/task_e_684e7e476e8c8322b95a4478e0fbc968