### PR TITLE
Fix habitability survival window

### DIFF
--- a/simulation_engine/core/stage_handlers.py
+++ b/simulation_engine/core/stage_handlers.py
@@ -128,7 +128,18 @@ def evaluate_habitability(parameters: RDEEParameterSchema) -> bool:
         return False
 
     if zone.default is not None and planet_distance.default is not None:
-        if not survival_window(planet_distance.default, zone.default):
+        window_ratio = (
+            parameters.sampling.survival_corridor_sensitivity_window.default
+            if parameters.sampling.survival_corridor_sensitivity_window.default
+            is not None
+            else 0.1
+        )
+        ok = survival_window(
+            planet_distance.default,
+            zone.default,
+            window_ratio,
+        )
+        if not ok:
             return False
 
     return True


### PR DESCRIPTION
## Summary
- handle survival_corridor_sensitivity_window parameter when evaluating habitability
- call `survival_window` with correct width argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e96cbe0f88322bc864fc00d0ed45e