### PR TITLE
Fix argument mismatch for scaled_fragility

### DIFF
--- a/simulation_engine/core/stage_handlers.py
+++ b/simulation_engine/core/stage_handlers.py
@@ -203,7 +203,10 @@ def evaluate_evolutionary(parameters: RDEEParameterSchema) -> bool:
     if not threshold_pass(complexity.default, complexity.min_value, complexity.max_value):
         return False
 
-    if not scaled_fragility(fragility.default):
+    ok_thresh = complexity.default
+    frag_mult = fragility.default
+    ok_frag = scaled_fragility(ok_thresh, frag_mult)
+    if not ok_frag:
         return False
 
     if extinction.default is not None:


### PR DESCRIPTION
## Summary
- correct `evaluate_evolutionary` to pass both arguments to `scaled_fragility`
- keep return logic unchanged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e981f00208322bbc2d1940531dafa