### PR TITLE
Add bifurcation perturbation logic

### DIFF
--- a/simulation_engine/core/bifurcation_handler.py
+++ b/simulation_engine/core/bifurcation_handler.py
@@ -1,110 +1,90 @@
 from __future__ import annotations
 
-"""Bifurcation control utilities for the RDEE recursion core."""
+"""Bifurcation utilities for parameter perturbations in recursive branching."""
 
-from dataclasses import fields, is_dataclass, replace
-from typing import Any, List, Optional
-import copy
-import random
+from dataclasses import asdict, fields, is_dataclass
+from typing import Any, List
+import numpy as np
 
 from interface.parameter_schema import ParameterSpec, RDEEParameterSchema
 
 
-def perturb_parameter(
-    parameter_spec: ParameterSpec,
-    perturbation_scale: float,
-    rng: Optional[random.Random] = None,
-) -> Any:
-    """Return a perturbed value for ``parameter_spec``.
+def _dict_to_dataclass(data: Any, cls: type) -> Any:
+    """Recursively rebuild dataclasses from ``data``.
 
     Parameters
     ----------
-    parameter_spec:
-        Specification describing the parameter to perturb.
-    perturbation_scale:
-        Fraction of the parameter range used as perturbation magnitude.
-    rng:
-        Random number generator instance. If ``None``, the default ``random``
-        module is used.
+    data:
+        Dictionary or primitive produced by :func:`dataclasses.asdict`.
+    cls:
+        Target dataclass type for reconstruction.
 
     Returns
     -------
     Any
-        Perturbed value constrained within ``min_value`` and ``max_value``.
+        Instance of ``cls`` populated with ``data``.
     """
+    if cls is ParameterSpec:
+        return ParameterSpec(**data)
+    if is_dataclass(cls):
+        kwargs = {}
+        for f in fields(cls):
+            kwargs[f.name] = _dict_to_dataclass(data[f.name], f.type)
+        return cls(**kwargs)
+    return data
 
-    if rng is None:
-        rng = random
 
-    if parameter_spec.min_value is None or parameter_spec.max_value is None:
-        return parameter_spec.default
+def _clone_schema(schema: RDEEParameterSchema) -> RDEEParameterSchema:
+    """Deep clone ``schema`` using :func:`dataclasses.asdict`."""
+    return _dict_to_dataclass(asdict(schema), RDEEParameterSchema)
 
-    base_value = (
-        parameter_spec.default
-        if parameter_spec.default is not None
-        else (parameter_spec.min_value + parameter_spec.max_value) / 2
+
+def _perturb_spec(spec: ParameterSpec, rng: np.random.Generator, scale: float) -> ParameterSpec:
+    """Return a copy of ``spec`` with its default value perturbed."""
+    default = spec.default
+    if default is None:
+        return spec
+    if spec.dtype not in (int, float):
+        raise TypeError(f"Unsupported dtype {spec.dtype!r} for parameter '{spec.name}'")
+
+    noise = rng.normal(0.0, scale)
+    perturbed = default * (1.0 + noise)
+
+    if spec.min_value is not None:
+        perturbed = max(spec.min_value, perturbed)
+    if spec.max_value is not None:
+        perturbed = min(spec.max_value, perturbed)
+
+    if spec.dtype is int:
+        perturbed = int(round(perturbed))
+        if spec.min_value is not None:
+            perturbed = max(int(spec.min_value), perturbed)
+        if spec.max_value is not None:
+            perturbed = min(int(spec.max_value), perturbed)
+    else:
+        perturbed = float(perturbed)
+
+    return ParameterSpec(
+        name=spec.name,
+        dtype=spec.dtype,
+        units=spec.units,
+        min_value=spec.min_value,
+        max_value=spec.max_value,
+        default=perturbed,
     )
 
-    full_range = float(parameter_spec.max_value - parameter_spec.min_value)
-    magnitude = full_range * perturbation_scale
-    delta = rng.uniform(-magnitude, magnitude)
-    new_value = base_value + delta
 
-    new_value = max(parameter_spec.min_value, min(parameter_spec.max_value, new_value))
-
-    if parameter_spec.dtype is int:
-        new_value = int(round(new_value))
-        new_value = max(int(parameter_spec.min_value), min(int(parameter_spec.max_value), new_value))
-    else:
-        new_value = float(new_value)
-
-    return new_value
-
-
-def perturb_schema(
-    base_schema: RDEEParameterSchema,
-    perturbation_scale: float,
-    rng: Optional[random.Random] = None,
-) -> RDEEParameterSchema:
-    """Return a perturbed clone of ``base_schema``.
-
-    Parameters
-    ----------
-    base_schema:
-        Schema providing parameter defaults to perturb.
-    perturbation_scale:
-        Fraction of parameter ranges used as perturbation magnitudes.
-    rng:
-        Random number generator instance. If ``None``, a new one is created.
-
-    Returns
-    -------
-    RDEEParameterSchema
-        Deep-copy of ``base_schema`` with perturbed ``ParameterSpec`` defaults.
-    """
-
-    if rng is None:
-        rng = random.Random()
-
-    schema_copy = copy.deepcopy(base_schema)
-
-    def _apply(obj: Any, parent: Any | None, name: str | None) -> None:
-        if isinstance(obj, ParameterSpec):
-            if obj.min_value is None and obj.max_value is None:
-                return
-            new_spec = replace(
-                obj,
-                default=perturb_parameter(obj, perturbation_scale, rng),
-            )
-            if parent is not None and name is not None:
-                setattr(parent, name, new_spec)
-            return
-        if is_dataclass(obj):
-            for field in fields(obj):
-                _apply(getattr(obj, field.name), obj, field.name)
-
-    _apply(schema_copy, None, None)
-    return schema_copy
+def _apply_perturbations(obj: Any, rng: np.random.Generator, scale: float) -> Any:
+    """Recursively perturb ``ParameterSpec`` defaults within ``obj``."""
+    if isinstance(obj, ParameterSpec):
+        return _perturb_spec(obj, rng, scale)
+    if is_dataclass(obj):
+        for f in fields(obj):
+            value = getattr(obj, f.name)
+            new_value = _apply_perturbations(value, rng, scale)
+            setattr(obj, f.name, new_value)
+        return obj
+    raise TypeError(f"Unsupported object type {type(obj).__name__} encountered")
 
 
 def generate_bifurcations(
@@ -112,28 +92,36 @@ def generate_bifurcations(
     branching_factor: int,
     perturbation_scale: float,
 ) -> List[RDEEParameterSchema]:
-    """Generate perturbed child schemas from a base set of parameters.
+    """Generate perturbed child parameter schemas from ``parameters``.
+
+    Each child is a deep clone of ``parameters`` with every numeric
+    :class:`ParameterSpec` default value perturbed by a multiplicative factor
+    drawn from a normal distribution with scale ``perturbation_scale``.
 
     Parameters
     ----------
     parameters:
         Base parameter schema to branch from.
     branching_factor:
-        Number of child schemas to generate.
+        Number of child schemas to create. Must be positive.
     perturbation_scale:
-        Magnitude of perturbations as a fraction of parameter ranges.
+        Standard deviation of the perturbation factor.
 
     Returns
     -------
     list[RDEEParameterSchema]
-        List of independent perturbed parameter schemas.
+        Independent parameter sets with stochastic perturbations applied.
     """
+    if branching_factor <= 0:
+        raise ValueError("branching_factor must be positive")
+    if perturbation_scale < 0.0:
+        raise ValueError("perturbation_scale must be non-negative")
 
-    bifurcations: List[RDEEParameterSchema] = []
+    children: List[RDEEParameterSchema] = []
     for _ in range(branching_factor):
-        rng = random.Random()
-        child = perturb_schema(parameters, perturbation_scale, rng)
-        bifurcations.append(child)
+        rng = np.random.default_rng()
+        child = _clone_schema(parameters)
+        child = _apply_perturbations(child, rng, perturbation_scale)
+        children.append(child)
 
-    return bifurcations
-
+    return children


### PR DESCRIPTION
## Summary
- implement `generate_bifurcations` using dataclass cloning via `asdict`
- add recursive perturbation of `ParameterSpec` defaults using numpy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eafbe24348322aaf74648c2efc98a